### PR TITLE
Update CodePipeline to deploy jenkins using cdk pipelines

### DIFF
--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -15,6 +15,7 @@
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
     "@aws-cdk/core:stackRelativeExports": true,
+    "@aws-cdk/core:newStyleStackSynthesis": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true,
     "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,

--- a/cdk/pipeline.py
+++ b/cdk/pipeline.py
@@ -35,7 +35,7 @@ class JenkinsPipeline(Stack):
     Parameters are passed to the pipeline through context values. An exception is raised if a required parameter
     is missing.
 
-    A staging stack is deploy if the staging-cert-arn context is provided.
+    A staging stack is deployed if the staging-cert-arn context is provided.
 
     """
 


### PR DESCRIPTION
With https://github.com/aws-lumberyard/o3de-jenkins-pipeline/pull/10 the jenkins server stack is also now defined in CDK. 

As a result, CodePipeline is being updated to use the CDK Pipelines construct to deploy the stacks directly. Defining each pipeline stage is no longer required. The pipeline also has a mechanism to update itself if the CodePipeline definition changes.

The prod deployment is currently gated with a simple approval step until a more appropriate mechanism is created (e.g. deployment windows, merge queues, etc.) 
