### PR TITLE
Add the option to use an existing VPC for the Jenkins CDK stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ The pipeline has the following stages:
     - branch: name of the branch used for pipeline deployments
     - cert-arn: This can be an SSL cert created by or imported into AWS Certificate Manager (ACM). See **ACM SSL Certificate Setup** below
     - codestar-connection: This grants access to CodePipeline to access the GitHub repo hosting your config files. See **CodeStar Connection Setup** below.
+- Optional context values
+    - vpc-id: Provide an ID to use an existing VPC for the Jenkins Server stack instead of creating a new one.
 
 ##### ACM SSL Certificate Setup
 

--- a/cdk/jenkins_server/jenkins_server.py
+++ b/cdk/jenkins_server/jenkins_server.py
@@ -69,12 +69,12 @@ class JenkinsServerStack(Stack):
     
     def _create_vpc(self):
         """Create a new VPC or use an existing one if a VPC ID is provided."""
-        if self.stack_tags['vpc-id'] == 'None':  # Context values/tags will be converted to string during synth
+        if self.stack_tags['vpc-id'] == 'None':  # Context values will be converted to string and cannot be empty during synth
             return ec2.Vpc(self, 'VPC',
                 cidr=self.stack_config['vpc']['cidr'],
                 nat_gateways=self.stack_config['vpc']['nat_gateways']
             )
-        return ec2.Vpc.from_lookup(self, self.stack_tags['vpc_id'])
+        return ec2.Vpc.from_lookup(self, self.stack_tags['vpc-id'])
 
     def _create_efs(self):
         """Create a file system with an access point for the jenkins home directory."""

--- a/cdk/jenkins_server/jenkins_server.py
+++ b/cdk/jenkins_server/jenkins_server.py
@@ -31,7 +31,7 @@ class JenkinsServerStack(Stack):
     Stack core components:
         - ECS/Fargate: Hosts the Jenkins server container
         - EFS: Stores the Jenkins home directory
-        - ALB: Load balencer to route traffic to the Fargate task
+        - ALB: Load balancer to route traffic to the Fargate task
 
     The options for each component are stored in the stack config file.
     """
@@ -42,10 +42,7 @@ class JenkinsServerStack(Stack):
         self.stack_config = self._load_stack_config(CONFIG_FILE)
         self.cert_arn = self._load_cert_arn()
 
-        self.vpc = ec2.Vpc(self, 'VPC',
-            cidr=self.stack_config['vpc']['cidr'],
-            nat_gateways=self.stack_config['vpc']['nat_gateways']
-        )
+        self.vpc = self._create_vpc()
         self.build_topic = sns.Topic(self, 'BuildTopic')
         self.log_group = logs.LogGroup(self, 'LogGroup')
         self.file_system, self.access_point = self._create_efs()
@@ -69,6 +66,15 @@ class JenkinsServerStack(Stack):
         if cert_arn is None:
             cert_arn = self.stack_tags['cert-arn']
         return cert_arn
+    
+    def _create_vpc(self):
+        """Create a new VPC or use an existing one if a VPC ID is provided."""
+        if self.stack_tags['vpc-id'] == 'None':  # Context values/tags will be converted to string during synth
+            return ec2.Vpc(self, 'VPC',
+                cidr=self.stack_config['vpc']['cidr'],
+                nat_gateways=self.stack_config['vpc']['nat_gateways']
+            )
+        return ec2.Vpc.from_lookup(self, self.stack_tags['vpc_id'])
 
     def _create_efs(self):
         """Create a file system with an access point for the jenkins home directory."""

--- a/cdk/jenkins_server/jenkins_server.py
+++ b/cdk/jenkins_server/jenkins_server.py
@@ -74,7 +74,7 @@ class JenkinsServerStack(Stack):
                 cidr=self.stack_config['vpc']['cidr'],
                 nat_gateways=self.stack_config['vpc']['nat_gateways']
             )
-        return ec2.Vpc.from_lookup(self, self.stack_tags['vpc-id'])
+        return ec2.Vpc.from_lookup(self, 'VPC', vpc_id=self.stack_tags['vpc-id'])
 
     def _create_efs(self):
         """Create a file system with an access point for the jenkins home directory."""

--- a/cdk/pipeline.py
+++ b/cdk/pipeline.py
@@ -21,12 +21,13 @@ class MissingContextError(Exception):
 
 class JenkinsServer(Stage):
     """Stage wrapper for the Jenkins server stack."""
-    def __init__(self, scope: Construct, id: str, cert_arn: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, id: str, cert_arn: str, vpc_id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
         JenkinsServerStack(self, 'JenkinsServerStack',
             tags={
-                'cert-arn': cert_arn
+                'cert-arn': cert_arn,
+                'vpc-id': vpc_id
             }
         )
 
@@ -106,6 +107,7 @@ class JenkinsPipeline(Stack):
         pipeline.add_stage(
             JenkinsServer(self, self.branch,
                 cert_arn=self.cert_arn,
+                vpc_id=self.vpc_id,
                 env=Environment(account=self.account, region=self.region)
             ),
             pre=[

--- a/cdk/pipeline.py
+++ b/cdk/pipeline.py
@@ -45,6 +45,7 @@ class JenkinsPipeline(Stack):
         self.repo = self._get_required_context('repo')
         self.branch = self._get_required_context('branch')
         self.cert_arn = self._get_required_context('cert-arn')
+        self.vpc_id = self.node.try_get_context('vpc-id')
         self.source = pipelines.CodePipelineSource.connection(self.repo, self.branch, connection_arn=self.codestar_connection)
 
         self._create_pipeline()
@@ -67,9 +68,10 @@ class JenkinsPipeline(Stack):
                     'pip install -r requirements.txt',
                     f'cdk synth --verbose \
                         --context codestar-connection={self.codestar_connection} \
-                        --context repo={self.repo}  \
+                        --context repo={self.repo} \
                         --context branch={self.branch} \
-                        --context cert-arn={self.cert_arn}'
+                        --context cert-arn={self.cert_arn} \
+                        --context vpc-id={self.vpc_id}'
                 ],
                 build_environment=codebuild.BuildEnvironment(
                     build_image=codebuild.LinuxBuildImage.STANDARD_5_0

--- a/cdk/pipeline.py
+++ b/cdk/pipeline.py
@@ -46,7 +46,7 @@ class JenkinsPipeline(Stack):
         self.repo = self._get_required_context('repo')
         self.branch = self._get_required_context('branch')
         self.cert_arn = self._get_required_context('cert-arn')
-        self.vpc_id = self.node.try_get_context('vpc-id')
+        self.vpc_id = self._get_optional_context('vpc-id')
         self.source = pipelines.CodePipelineSource.connection(self.repo, self.branch, connection_arn=self.codestar_connection)
 
         self._create_pipeline()
@@ -58,6 +58,10 @@ class JenkinsPipeline(Stack):
             print(f'Required context missing: {context_name}')
             raise MissingContextError
         return context_value
+    
+    def _get_optional_context(self, context_name):
+        """Get context value and set it to 'None' if it does not exist. Some constructs cannot have a null or empty string ID."""
+        return self.node.try_get_context(context_name) or 'None'
 
     def _create_pipeline(self):
         pipeline = pipelines.CodePipeline(self, 'Pipeline',

--- a/cdk/tests/test_jenkins_pipeline_stack.py
+++ b/cdk/tests/test_jenkins_pipeline_stack.py
@@ -20,12 +20,14 @@ BRANCH = "test"
 CERT_ARN = f"arn:aws:acm:{REGION}:{ACCOUNT}:certificate/certificate_id"
 CODESTAR_CONNECTION = f"arn:aws:codestar-connections:{REGION}:{ACCOUNT}:connection/codestar_id"
 REPO = "o3de/repo"
+VPC_ID = "vpc-01234567890"
 
 TEST_CONTEXT = {
     "branch": BRANCH,
     "cert-arn": CERT_ARN,
     "codestar-connection": CODESTAR_CONNECTION,
-    "repo": REPO
+    "repo": REPO,
+    "vpc-id": VPC_ID
   }
 
 

--- a/cdk/tests/test_jenkins_server_stack.py
+++ b/cdk/tests/test_jenkins_server_stack.py
@@ -16,7 +16,7 @@ from test_jenkins_pipeline_stack import CERT_ARN, TEST_CONTEXT
 
 ACCOUNT = "123456789012"
 REGION = "us-west-2"
-VPC_ID = "None"  # Used to test that VPC is created if one if not provided
+VPC_ID = "None"  # Used to test that a VPC is still created if one is not provided
 
 
 @pytest.fixture

--- a/cdk/tests/test_jenkins_server_stack.py
+++ b/cdk/tests/test_jenkins_server_stack.py
@@ -16,12 +16,19 @@ from test_jenkins_pipeline_stack import CERT_ARN, TEST_CONTEXT
 
 ACCOUNT = "123456789012"
 REGION = "us-west-2"
+VPC_ID = "None"  # Used to test that VPC is created if one if not provided
 
 
 @pytest.fixture
 def template():
     app = cdk.App(context=TEST_CONTEXT)
-    jenkins_server_stack = JenkinsServerStack(app, 'JenkinsServerStack', env=cdk.Environment(account=ACCOUNT, region=REGION))
+    jenkins_server_stack = JenkinsServerStack(app, 'JenkinsServerStack', 
+                                                env=cdk.Environment(account=ACCOUNT, region=REGION),
+                                                tags={
+                                                    'cert-arn': CERT_ARN,
+                                                    'vpc-id': VPC_ID
+                                                }
+                                              )
 
     return Template.from_stack(jenkins_server_stack)
 


### PR DESCRIPTION
This PR adds an optional context value that allows the stack to use an existing VPC for the Jenkins Server. This will allow easier migrations to environments that already have resources deployed to an existing VPC. 

Testing:
- Updated tests to verify a vpc is still created in the stack if an ID is not provided. 
- Tested deployment in sandbox environment both with a VPC ID and without. 