### PR TITLE
Add ECS deployment circuit breaker

### DIFF
--- a/cdk/jenkins_server/jenkins_server.py
+++ b/cdk/jenkins_server/jenkins_server.py
@@ -179,7 +179,8 @@ class JenkinsServerStack(Stack):
             assign_public_ip=True,
             platform_version=ecs.FargatePlatformVersion.VERSION1_4,
             cluster=cluster,
-            desired_count=ecs_config['service']['desired_count']
+            desired_count=ecs_config['service']['desired_count'],
+            circuit_breaker=ecs.DeploymentCircuitBreaker(rollback=True)
         )
 
         self.file_system.connections.allow_default_port_from(fargate_service)


### PR DESCRIPTION
This change adds the deployment circuit breaker to the ECS service config. This prevents ECS from continuously attempting to deploy tasks that fail to start or pass health checks. Otherwise the failed deployment needs to be manually cancelled through CloudFormation. 
