### PR TITLE
Update aws-cdk-lib to latest

### DIFF
--- a/cdk/requirements.txt
+++ b/cdk/requirements.txt
@@ -1,10 +1,10 @@
 attrs==22.1.0
-aws-cdk-lib==2.38.1
+aws-cdk-lib==2.95.1
 cattrs==22.1.0
 constructs==10.1.84
 exceptiongroup==1.0.0rc8
 iniconfig==1.1.1
-jsii==1.65.0
+jsii==1.88.0
 packaging==21.3
 pluggy==1.0.0
 publication==0.0.3


### PR DESCRIPTION
This unblocks https://github.com/o3de/o3de-jenkins-pipeline/pull/32 

This updates aws-cdk-lib to a version that supports the Elastic throughput mode for EFS. 