### PR TITLE
Add example groovy pipeline job

### DIFF
--- a/configs/jobs.yaml
+++ b/configs/jobs.yaml
@@ -1,0 +1,5 @@
+# Config file for Job DSL plugin.
+# Add a file entry for each groovy script containing job definitions.
+# Recommended: Store files in JENKINS_LOCAL to prevent state data in JENKINS_HOME
+jobs:
+  - file: ${JENKINS_LOCAL}/jobdsl/o3de_example.groovy

--- a/jobdsl/o3de_example.groovy
+++ b/jobdsl/o3de_example.groovy
@@ -28,17 +28,6 @@ multibranchPipelineJob('O3DE-Example') {
                             triggeredBranchesRegex('^$')
                         }
                     }
-                    namedExceptions {
-                        named {
-                            name('main')
-                        }
-                        named {
-                            name('development')
-                        }
-                        named {
-                            name('stabilization/*')
-                        }
-                    }
                 }
             }
         }
@@ -54,11 +43,6 @@ multibranchPipelineJob('O3DE-Example') {
         discardOldItems {
             daysToKeep(7)
             numToKeep(14)
-        }
-    }
-    triggers {
-        periodicFolderTrigger {
-            interval('5m')
         }
     }
 }

--- a/jobdsl/o3de_example.groovy
+++ b/jobdsl/o3de_example.groovy
@@ -1,0 +1,64 @@
+multibranchPipelineJob('O3DE-Example') {
+    branchSources {
+        branchSource {
+            source {
+                github {
+                    id('O3DE-Example')
+                    configuredByUrl(false)
+                    repoOwner('o3de')
+                    repository('o3de')
+                    repositoryUrl('https://github.com/o3de/o3de.git')
+                    traits {
+                        authorInChangelogTrait()
+                        gitHubBranchDiscovery {
+                            strategyId(3)
+                        }
+                        gitHubPullRequestDiscovery {
+                            strategyId(1)
+                        }
+                        pruneStaleBranchTrait()
+                        pruneStaleTagTrait()
+                    }
+                }
+            }
+            strategy {
+                namedBranchesDifferent {
+                    defaultProperties {
+                        suppressAutomaticTriggering {
+                            triggeredBranchesRegex('^$')
+                        }
+                    }
+                    namedExceptions {
+                        named {
+                            name('main')
+                        }
+                        named {
+                            name('development')
+                        }
+                        named {
+                            name('stabilization/*')
+                        }
+                    }
+                }
+            }
+        }
+    }
+    description('Example pipeline job for O3DE, a full-featured, real-time open source 3D engine.')
+    displayName('O3DE Example Pipeline')
+    factory {
+        workflowBranchProjectFactory {
+            scriptPath('scripts/build/Jenkins/Jenkinsfile')
+        }
+    }
+    orphanedItemStrategy {
+        discardOldItems {
+            daysToKeep(7)
+            numToKeep(14)
+        }
+    }
+    triggers {
+        periodicFolderTrigger {
+            interval('5m')
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an example groovy job for the O3DE repo. This showcases how an O3DE pipeline can be setup and provides an initial job to customize on a first deployment. 

Tested on the sandbox.